### PR TITLE
Increase the max width of the documentation on desktop

### DIFF
--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -138,7 +138,7 @@
   --toc-width: calc(162 / var(--rem-base) * 1rem);
   --toc-width--widescreen: calc(216 / var(--rem-base) * 1rem);
   --doc-max-width: calc(720 / var(--rem-base) * 1rem);
-  --doc-max-width--desktop: calc(828 / var(--rem-base) * 1rem);
+  --doc-max-width--desktop: calc(1125 / var(--rem-base) * 1rem);
   /* stacking */
   --z-index-nav: 1;
   --z-index-toolbar: 2;


### PR DESCRIPTION
Change increases the max size of the documentation width from 46rem to 62.5rem (the legacy vulkan documentation page's content width).  This should help resolve KhronosGroup/Vulkan-Site#5 where there is a significant amount of unused whitespace on the right hand side of the display.  This also helps to resolve KhronosGroup/Vulkan-Site#21 where some wide tables break the navigation.