### PR TITLE
Restrict searchbar to current component by default

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -4,8 +4,12 @@
       <a class="navbar-item" href="{{{or site.url siteRootPath}}}"><img class="navbar-item" alt="Vulkan White Label" src="{{{uiRootPath}}}/Vulkan_Docs.svg" /></a>
       {{#if env.SITE_SEARCH_PROVIDER}}
       <div class="navbar-item search hide-for-print">
-        <div id="search-field" class="field">
-          <label for="search-input"></label><input id="search-input" type="text" placeholder="Search the docs"{{#if page.home}} autofocus{{/if}}>
+        <div id="search-field" class="field has-filter">
+          <label for="search-input"></label>
+          <input id="search-input" type="text" placeholder="Search the docs"{{#if page.home}} autofocus{{/if}}>
+          <label class="filter checkbox">
+            <input type="checkbox" data-facet-filter="component:{{page.component.name}}" checked> In this project
+          </label>
         </div>
       </div>
       {{/if}}


### PR DESCRIPTION
Per https://gitlab.com/antora/antora-lunr-extension#user-content-restrict-search-to-current-component This makes the search restricted to the current component by default. It can easily be altered so search is for all components by default.

Closes https://github.com/KhronosGroup/Vulkan-Site/issues/50