### PR TITLE
Remove empty footer

### DIFF
--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -1,6 +1,6 @@
-<footer class="footer">
+{{!-- <footer class="footer">
     <!--
   <p>This page was built using the Antora default UI.</p>
   <p>The source code for this UI is licensed under the terms of the MPL-2.0 license.</p>
     -->
-</footer>
+</footer> --}}


### PR DESCRIPTION
This PR removes (or better disables) the currently empty footer. That empty footer results in an odd way of scrolling past the end of a page's content and usability of the docs site is better without that footer.

See https://github.com/KhronosGroup/antora-ui-khronos/issues/13 (I can't seem to move that issue over here)