### PR TITLE
Change background color of sidebar blocks from gray to white

### DIFF
--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -108,7 +108,7 @@
   --quote-border-color: var(--color-gray-70);
   --quote-font-color: var(--color-gray-70);
   --quote-attribution-font-color: var(--color-gray-40);
-  --sidebar-background: var(--color-smoke-90);
+  --sidebar-background: var(--color-white);
   --table-border-color: var(--panel-border-color);
   --table-stripe-background: var(--panel-background);
   --table-footer-background: linear-gradient(to bottom, var(--color-smoke-70) 0%, var(--color-white) 100%);


### PR DESCRIPTION
This changes the visual appearance from mixed black text on gray background and black text on white background on gray background (for code-like markup), to just black on white background, like the HTML documents in the registry. We might want to put a box around the sidebar blocks, as the registry CSS does, but this is a visual improvement in and of itself and I think we should just take it.

Closes KhronosGroup/Vulkan-Site#56

![new](https://github.com/user-attachments/assets/5c962be2-c1da-4ec1-886b-1483c1a25195)

![old](https://github.com/user-attachments/assets/f86c68cf-d95f-42fd-b84e-bf0b6ebf2a55)




Note, this affects *all* sidebar blocks in the document, not just the Valid Usage blocks. There are a lot of sidebar blocks in the spec content besides VU blocks, and it will also affect the other components. I don't think this is a drawback - if it's hard to read for VU statements, it's hard to read for anything else as well.