### PR TITLE
Invert SVG images in dark mode

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -1085,3 +1085,7 @@
   text-align: right;
   width: 1.5em;
 }
+
+:root.dark img[src$=".svg"] {
+  filter: invert(1);
+}


### PR DESCRIPTION
This PR inverts SVG images when dark mode is selected and fixes https://github.com/KhronosGroup/Vulkan-Site/issues/102

Note: To properly work, this needs #17 to be merged. Without that PR, the CSS class for dark/light mode is not always set.