### PR TITLE
Invert toolbar buttons in dark mode

### DIFF
--- a/src/css/toolbar.css
+++ b/src/css/toolbar.css
@@ -66,3 +66,15 @@
 .toolbar .edit-this-page a {
   color: var(--toolbar-muted-color);
 }
+
+:root.dark {
+  .toolbar button {
+    -webkit-filter: invert(1);
+    filter: invert(1);
+  }
+
+  .toolbar .home-link {
+    -webkit-filter: invert(1);
+    filter: invert(1);
+  }
+}


### PR DESCRIPTION
In mobile layout, navigation is collapsed and can be accessed via buttons in the toolbar. Due to the color of the buttons and the background of said toolbar, those buttons become invisible in dark mode:

![image](https://github.com/user-attachments/assets/4841419a-98b8-47a0-97c6-76b0b1c1b0f0)

This PR adds an invert filter to those buttons, so they become visible again:

![image](https://github.com/user-attachments/assets/1c5ea9a8-9ad3-4e35-8a6f-8650abb900bf)

Fixes https://github.com/KhronosGroup/Vulkan-Site/issues/107