### PR TITLE
Add asciidoctor tabs plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "license": "MPL-2.0",
       "devDependencies": {
         "@asciidoctor/core": "~2.2",
+        "@asciidoctor/tabs": "^1.0.0-beta.6",
         "@fontsource/roboto": "~4.5",
         "@fontsource/roboto-mono": "~4.5",
         "@vscode/gulp-vinyl-zip": "~2.5",
@@ -76,6 +77,15 @@
         "node": ">=8.11",
         "npm": ">=5.0.0",
         "yarn": ">=1.1.0"
+      }
+    },
+    "node_modules/@asciidoctor/tabs": {
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/tabs/-/tabs-1.0.0-beta.6.tgz",
+      "integrity": "sha512-gGZnW7UfRXnbiyKNd9PpGKtSuD8+DsqaaTSbQ1dHVkZ76NaolLhdQg8RW6/xqN3pX1vWZEcF4e81+Oe9rNRWxg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "devDependencies": {
     "@asciidoctor/core": "~2.2",
+    "@asciidoctor/tabs": "^1.0.0-beta.6",
     "@fontsource/roboto": "~4.5",
     "@fontsource/roboto-mono": "~4.5",
     "@vscode/gulp-vinyl-zip": "~2.5",

--- a/src/css/vendor/tabs.css
+++ b/src/css/vendor/tabs.css
@@ -1,0 +1,1 @@
+@import "@asciidoctor/tabs"

--- a/src/js/vendor/tabs.bundle.js
+++ b/src/js/vendor/tabs.bundle.js
@@ -1,0 +1,1 @@
+require('@asciidoctor/tabs')

--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -3,3 +3,4 @@
 {{#if env.SITE_SEARCH_PROVIDER}}
 {{> search-scripts}}
 {{/if}}
+<script async src="{{{uiRootPath}}}/js/vendor/tabs.js"></script>

--- a/src/partials/head-styles.hbs
+++ b/src/partials/head-styles.hbs
@@ -1,1 +1,2 @@
     <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
+    <link rel="stylesheet" href="{{{uiRootPath}}}/css/vendor/tabs.css">


### PR DESCRIPTION
This PR adds the [asciidoctor tabs plugin](https://github.com/asciidoctor/asciidoctor-tabs) to the UI for the docs site. With this plugin we can add tabbed blocks to the documentation. Here is a sample of how it could look like in the tutorial to toggle between the C/C++ headers:

![image](https://github.com/user-attachments/assets/7604b4d3-5d2d-4182-8fb6-fefd4887e08e)
