### PR TITLE
Add JavaScript file for new splitter to linter ignores

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+split.js


### PR DESCRIPTION
With the splitter addition a new external JavaScript file was added. In projects that have CI (which this does not) this can cause build failures, which might impact the next build of the docs site.

This PR adds that file to the linter's ignore.