### PR TITLE
Fix `hasOwnProperty` usage in multilang script to prevent prototype p…

### DIFF
--- a/src/js/20-multilang.js
+++ b/src/js/20-multilang.js
@@ -1,3 +1,4 @@
+/* eslint-env browser */
 (function () {
   'use strict'
 
@@ -20,7 +21,7 @@
           buf = []
         }
         curr = mStart[1]
-        if (!blocks.hasOwnProperty(curr)) order.push(curr)
+        if (!Object.prototype.hasOwnProperty.call(blocks, curr)) order.push(curr)
         // reset buffer for this lang
         buf = []
         continue


### PR DESCRIPTION
…ollution warnings

Updated the `hasOwnProperty` check to use `Object.prototype.hasOwnProperty.call` for safer property access in the multilang script. Added `eslint-env browser` directive for linter configuration.

This fixes the problems with #30 