### PR TITLE
Refactor multilang script for clarity, suppress `max-len` in SPIR-V v…

### DIFF
--- a/src/css/highlight.css
+++ b/src/css/highlight.css
@@ -88,4 +88,9 @@
 /* Multilang code block support */
 pre.multilang code { display: none; }
 pre.multilang code.is-active { display: block; }
-.code-lang-selector { margin: 0 0 0.5rem; font: inherit; font-size: 0.9em; }
+
+.code-lang-selector {
+  margin: 0 0 0.5rem;
+  font: inherit;
+  font-size: 0.9em;
+}

--- a/src/js/20-multilang.js
+++ b/src/js/20-multilang.js
@@ -79,7 +79,14 @@
     const dl = (pre.dataset && pre.dataset.languages) || (code.dataset && code.dataset.languages)
     if (dl) declared = dl.split(',').map((s) => s.trim()).filter(Boolean)
 
-    const langs = declared.length ? declared.filter((l) => parsed.langs.includes(l)).concat(parsed.langs.filter((l) => !declared.includes(l))) : parsed.langs
+    let langs
+    if (declared.length) {
+      const declaredInParsed = declared.filter((l) => parsed.langs.includes(l))
+      const rest = parsed.langs.filter((l) => !declared.includes(l))
+      langs = declaredInParsed.concat(rest)
+    } else {
+      langs = parsed.langs
+    }
     pre.dataset.languages = langs.join(',')
 
     // build selector
@@ -143,7 +150,8 @@
     blocks.forEach(function (code) {
       var pre = code.parentNode
       // only process if language is marked as multilang or content contains markers
-      var isMulti = (code.getAttribute('data-lang') || '').toLowerCase() === 'multilang' || /\n\s*\/\/\s*START\s+[A-Za-z0-9_-]+/i.test(code.textContent)
+      var isMulti = (code.getAttribute('data-lang') || '').toLowerCase() === 'multilang' ||
+        /\n\s*\/\/\s*START\s+[A-Za-z0-9_-]+/i.test(code.textContent)
       if (!isMulti) return
       try { enhanceMultilangBlock(pre, code) } catch (e) { /* fail-safe */ }
     })

--- a/src/js/vendor/spirv.js
+++ b/src/js/vendor/spirv.js
@@ -1,6 +1,9 @@
 // Copyright 2025 Holochip Inc
 // SPDX-License-Identifier: MIT
 
+/* eslint-disable max-len */
+// NOTE: max-len disabled for vendor file to preserve upstream formatting while avoiding lint noise.
+
 // Based on hlsl.js structure
 // SPIR-V language definition for highlight.js
 


### PR DESCRIPTION
…endor file, and improve CSS formatting for code language selector